### PR TITLE
FIX: Resolve macOS DMG build hdiutil resize error

### DIFF
--- a/package.json
+++ b/package.json
@@ -143,6 +143,26 @@
       "type": "distribution",
       "icon": "assets/icons/icon.png"
     },
+    "dmg": {
+      "format": "ULFO",
+      "window": {
+        "width": 540,
+        "height": 380
+      },
+      "contents": [
+        {
+          "x": 140,
+          "y": 200,
+          "type": "file"
+        },
+        {
+          "x": 400,
+          "y": 200,
+          "type": "link",
+          "path": "/Applications"
+        }
+      ]
+    },
     "linux": {
       "target": [
         {


### PR DESCRIPTION
## Summary
Fix the macOS DMG build failure caused by hdiutil resize error during v1.0.1 release build.

## Problem
Build was failing with:
```
⨯ Exit code: 6. Command failed: hdiutil resize -size 690152634.6 /private/var/folders/.../0.dmg
hdiutil: resize: failed. Device not configured (6)
```

## Solution
- Add explicit DMG configuration with ULFO format to prevent hdiutil resize failures
- Configure DMG window size and drag-drop layout for better UX
- This is a common issue with electron-builder on macOS when DMG format is not explicitly specified

## Changes
- Added `dmg` section to package.json with explicit format and layout configuration
- Uses ULFO format which is more reliable than default APFS for universal builds

## Test plan
- [ ] Verify DMG builds without hdiutil errors
- [ ] Test DMG installation on macOS
- [ ] Confirm both DMG and ZIP are created for auto-updater

🤖 Generated with [Claude Code](https://claude.ai/code)