### PR TITLE
FIX: Auto-generate latest-mac.yml for auto-updater

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -233,12 +233,35 @@ jobs:
       - name: Package for Linux DEB
         run: npm run package:linux:deb
 
+      - name: Generate Linux auto-updater metadata
+        run: |
+          # Generate latest-linux.yml for auto-updater
+          DEB_FILE=$(ls dist/*.deb | head -1)
+          DEB_NAME=$(basename "$DEB_FILE")
+          DEB_SIZE=$(stat -c%s "$DEB_FILE")
+          DEB_SHA512=$(sha512sum "$DEB_FILE" | cut -d' ' -f1)
+          
+          cat > dist/latest-linux.yml << EOF
+          version: ${{ needs.prepare-release.outputs.version }}
+          files:
+            - url: ${DEB_NAME}
+              sha512: ${DEB_SHA512}
+              size: ${DEB_SIZE}
+          path: ${DEB_NAME}
+          sha512: ${DEB_SHA512}
+          releaseDate: $(date -u +"%Y-%m-%dT%H:%M:%S.%3NZ")
+          EOF
+          
+          echo "Generated latest-linux.yml:"
+          cat dist/latest-linux.yml
+
       - name: Upload Linux DEB artifacts
         uses: actions/upload-artifact@v4
         with:
           name: cctracker-linux-deb-${{ needs.prepare-release.outputs.version }}
           path: |
             dist/*.deb
+            dist/latest-linux.yml
           retention-days: 30
 
   # Build for Linux TAR.GZ (Universal Linux)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -147,12 +147,41 @@ jobs:
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         run: npm run package:mac
 
+      - name: Generate auto-updater metadata
+        run: |
+          # Generate latest-mac.yml for auto-updater
+          ZIP_FILE=$(ls dist/*.zip | head -1)
+          ZIP_NAME=$(basename "$ZIP_FILE")
+          ZIP_SIZE=$(stat -f%z "$ZIP_FILE")
+          ZIP_SHA512=$(shasum -a 512 "$ZIP_FILE" | cut -d' ' -f1)
+          BLOCKMAP_FILE="${ZIP_FILE}.blockmap"
+          BLOCKMAP_SIZE=$(stat -f%z "$BLOCKMAP_FILE")
+          BLOCKMAP_SHA512=$(shasum -a 512 "$BLOCKMAP_FILE" | cut -d' ' -f1)
+          
+          cat > dist/latest-mac.yml << EOF
+          version: ${{ needs.prepare-release.outputs.version }}
+          files:
+            - url: ${ZIP_NAME}
+              sha512: ${ZIP_SHA512}
+              size: ${ZIP_SIZE}
+              blockMapSize: ${BLOCKMAP_SIZE}
+          path: ${ZIP_NAME}
+          sha512: ${ZIP_SHA512}
+          releaseDate: $(date -u +"%Y-%m-%dT%H:%M:%S.%3NZ")
+          EOF
+          
+          echo "Generated latest-mac.yml:"
+          cat dist/latest-mac.yml
+
       - name: Upload macOS artifacts
         uses: actions/upload-artifact@v4
         with:
           name: cctracker-mac-universal-${{ needs.prepare-release.outputs.version }}
           path: |
             dist/*.dmg
+            dist/*.zip
+            dist/*.blockmap
+            dist/latest-mac.yml
           retention-days: 30
 
   # Build for Linux DEB (Debian/Ubuntu)

--- a/electron-builder-zip.json
+++ b/electron-builder-zip.json
@@ -42,9 +42,11 @@
     "type": "distribution",
     "icon": "assets/icons/icon.png"
   },
-  "publish": {
-    "provider": "github",
-    "owner": "miwi-fbsd",
-    "repo": "CCTracker"
-  }
+  "publish": [
+    {
+      "provider": "github",
+      "owner": "miwi-fbsd",
+      "repo": "CCTracker"
+    }
+  ]
 }


### PR DESCRIPTION
## Problem
Auto-updater was failing because `latest-mac.yml` metadata file was missing from releases.

## Solution
- **Auto-generate `latest-mac.yml`** in CI/CD after packaging
- **Upload all required files**: ZIP, DMG, blockmap, and metadata
- **Calculate proper SHA512 checksums** for auto-updater validation

## Changes
- Added metadata generation step in build workflow
- Updated artifact upload to include ZIP, blockmap, and latest-mac.yml files
- Fixed package.json to use `--publish never` (CI handles publishing)

## Result
Auto-updater will now find the metadata file at:
`https://github.com/miwi-fbsd/CCTracker/releases/download/v1.0.1/latest-mac.yml`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced build and release process to include metadata files for auto-updater support on macOS and Linux DEB builds.
  * Updated artifact uploads to include new metadata files for both platforms.
  * Adjusted configuration structure for publishing settings to improve compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->