### PR TITLE
FIX: Remove publish config causing GitHub token requirement

### DIFF
--- a/electron-builder-zip.json
+++ b/electron-builder-zip.json
@@ -41,12 +41,5 @@
     "darkModeSupport": true,
     "type": "distribution",
     "icon": "assets/icons/icon.png"
-  },
-  "publish": [
-    {
-      "provider": "github",
-      "owner": "miwi-fbsd",
-      "repo": "CCTracker"
-    }
-  ]
+  }
 }


### PR DESCRIPTION
## Problem
Build was failing with "GitHub Personal Access Token is not set" because electron-builder configs had publish settings trying to push to GitHub.

## Solution
- **Remove publish configuration** from electron-builder-zip.json
- **Remove GH_TOKEN requirement** from workflow
- **Build artifacts locally only** - let CI handle uploading to releases

## Result
- No more token requirements
- Builds should complete successfully
- YML metadata files will be generated by CI steps, not electron-builder publish

Back to working state without tokens like before!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated configuration by removing the GitHub publishing settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->