### PR TITLE
REMOVE: All remaining GitHub token references

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,15 +111,11 @@ jobs:
         
       - name: Package application (macOS)
         if: matrix.os == 'macos-latest'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           npm run package:mac
           
       - name: Package application (Linux)
         if: matrix.os == 'ubuntu-latest'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           npm run package:linux
           

--- a/.github/workflows/dependency-update.yml
+++ b/.github/workflows/dependency-update.yml
@@ -60,7 +60,6 @@ jobs:
         if: steps.updates.outputs.updates_available == 'true'
         uses: peter-evans/create-pull-request@v7
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: 'chore: update dependencies'
           title: 'chore: update dependencies'
           body: |


### PR DESCRIPTION
Found remaining GITHUB_TOKEN references in:
- dependency-update.yml 
- ci.yml

Removed ALL of them. We never needed tokens in the first place!