### PR TITLE
FIX: Remove trailing comma in package.json causing JSON parse error

### DIFF
--- a/package.json
+++ b/package.json
@@ -182,7 +182,7 @@
         "--deb-field",
         "Maintainer: CCTracker Team <miwi@FreeBSD.org>"
       ]
-    },
+    }
   },
   "optionalDependencies": {
     "fsevents": "^2.3.3"


### PR DESCRIPTION
## Summary
• Fixed JSON syntax error in package.json - removed trailing comma after build section
• This was causing all GitHub Actions workflows to fail with "EJSONPARSE" error
• Error occurred at position 5682 where Node.js expected double-quoted property name

## Root Cause
The package.json had an invalid trailing comma after the `build` configuration block:
```json
    },
  },  // <- This trailing comma was invalid JSON
```

## Fix Applied
Removed the trailing comma to make valid JSON:
```json
    }
  },
```

## Test Plan
- [x] Validated JSON syntax with `node -e "JSON.parse(...)"`
- [x] Confirmed package.json can be parsed without errors
- [x] All subsequent workflow runs should now pass the prepare step

🤖 Generated with [Claude Code](https://claude.ai/code)