### PR TITLE
FIX: Add release permissions to workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,10 @@ on:
   push:
     tags: ['v*']
 
+permissions:
+  contents: write
+  discussions: write
+
 env:
   NODE_VERSION: '20'
 


### PR DESCRIPTION
## Summary
• Added `contents: write` and `discussions: write` permissions to release workflow
• Fixes 403 "Resource not accessible by integration" error when creating GitHub releases
• Uses automatic GITHUB_TOKEN with expanded permissions - no manual token setup required

## Root Cause
The `softprops/action-gh-release@v2` action failed with:
```
⚠️ GitHub release failed with status: 403
{"message":"Resource not accessible by integration"}
```

This happens because the default GITHUB_TOKEN has read-only permissions by default.

## Fix Applied
Added permissions block to grant necessary access:
```yaml
permissions:
  contents: write      # Required to create releases and upload assets
  discussions: write   # Required to generate release notes
```

## Technical Details
- ✅ Still uses automatic GITHUB_TOKEN (no manual tokens)
- ✅ No secrets configuration required
- ✅ Standard GitHub Actions pattern for releases
- ✅ Expands default token permissions without additional setup

🤖 Generated with [Claude Code](https://claude.ai/code)