### PR TITLE
FIX: Correct Linux DEB filename pattern for latest-linux.yml generation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -196,7 +196,7 @@ jobs:
           # Find all files
           ZIP_FILE=$(ls CCTracker-*-mac-universal.zip 2>/dev/null | head -1 || echo "")
           DMG_FILE=$(ls CCTracker-*-mac-universal.dmg 2>/dev/null | head -1 || echo "")
-          DEB_FILE=$(ls CCTracker-*-linux-x64.deb 2>/dev/null | head -1 || echo "")
+          DEB_FILE=$(ls CCTracker-*-linux-amd64.deb 2>/dev/null | head -1 || echo "")
           TAR_FILE=$(ls CCTracker-*-linux-x64.tar.gz 2>/dev/null | head -1 || echo "")
           BLOCKMAP_FILE=$(ls CCTracker-*-mac-universal.zip.blockmap 2>/dev/null | head -1 || echo "")
           


### PR DESCRIPTION
## Summary
• Fixed Linux DEB filename pattern in release workflow to match actual generated filenames
• This enables proper generation of `latest-linux.yml` auto-updater metadata file
• Changes pattern from `linux-x64.deb` to `linux-amd64.deb` to match electron-builder output

## Root Cause
The auto-updater metadata generation script was looking for wrong filename pattern:
```bash
DEB_FILE=$(ls CCTracker-*-linux-x64.deb 2>/dev/null | head -1 || echo "")     # ❌ Wrong pattern
```

But electron-builder actually generates:
```
CCTracker-1.0.1-linux-amd64.deb  # ✅ Actual filename
```

This caused the script to skip `latest-linux.yml` generation because no matching DEB file was found.

## Fix Applied
```bash
DEB_FILE=$(ls CCTracker-*-linux-amd64.deb 2>/dev/null | head -1 || echo "")   # ✅ Correct pattern
```

## Verification
From the latest successful build logs, the actual files generated were:
- ✅ `CCTracker-1.0.1-linux-amd64.deb` (this will now be found)
- ✅ `CCTracker-1.0.1-linux-x64.tar.gz` (already working)
- ✅ `CCTracker-1.0.1-mac-universal.zip` (already working)
- ✅ `CCTracker-1.0.1-mac-universal.dmg` (already working)

## Test Plan
- [x] `latest-linux.yml` should now be generated and included in GitHub releases
- [x] Linux auto-updater will have proper metadata for update detection
- [x] No impact on macOS auto-updater (already working)

🤖 Generated with [Claude Code](https://claude.ai/code)