### PR TITLE
BUMP: Version 1.0.3 - Hybrid auto-updater release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cost-tracker",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Complete Claude API Cost Monitoring Tool - React/Electron",
   "main": "dist/main.js",
   "scripts": {


### PR DESCRIPTION
## Summary
• Bumped version to 1.0.3 for testing the new hybrid auto-updater system
• This release includes the manual update fallback functionality
• Ready for testing manual update notifications via GitHub API

## Testing Plan
1. Users with 1.0.2 can test the manual update check in Settings > About
2. Should detect 1.0.3 as available and show GitHub download dialog
3. Verifies the hybrid update system works properly

🤖 Generated with [Claude Code](https://claude.ai/code)