### PR TITLE
FIX: AutoUpdaterService code style improvements

### DIFF
--- a/src/main/services/AutoUpdaterService.ts
+++ b/src/main/services/AutoUpdaterService.ts
@@ -1,12 +1,11 @@
-import { autoUpdater } from 'electron-updater';
 import { dialog, shell, type BrowserWindow } from 'electron';
 import { log } from '@shared/utils/logger';
 import { getVersion } from '@shared/utils/version';
 
 export class AutoUpdaterService {
   private mainWindow: BrowserWindow | null = null;
-  private updateCheckInProgress = false;
-  private updateDownloaded = false;
+  private readonly updateCheckInProgress = false;
+  private readonly updateDownloaded = false;
   private readonly repoOwner = 'miwi-fbsd';
   private readonly repoName = 'CCTracker';
   private lastManualCheckTime = 0;
@@ -46,9 +45,9 @@ export class AutoUpdaterService {
   /**
    * Download and install update (disabled - manual only)
    */
-  async downloadAndInstallUpdate(): Promise<void> {
+  downloadAndInstallUpdate(): Promise<void> {
     log.info('Auto-download disabled - please use manual update check', 'AutoUpdater');
-    throw new Error('Automatic downloads disabled. Please use manual update check.');
+    return Promise.reject(new Error('Automatic downloads disabled. Please use manual update check.'));
   }
 
   /**


### PR DESCRIPTION
## Summary
- Remove unused autoUpdater import from electron-updater
- Make updateCheckInProgress and updateDownloaded readonly since they're never modified
- Fix downloadAndInstallUpdate return type consistency by using Promise.reject

## Test plan
- [ ] Code compiles without TypeScript errors
- [ ] AutoUpdater service still works with manual update checks
- [ ] No functional changes, only code style improvements

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal handling of update status for greater reliability. No visible changes to user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->